### PR TITLE
Write error message locations in the form file:line:column:

### DIFF
--- a/src/Test/Info2/Cyp.hs
+++ b/src/Test/Info2/Cyp.hs
@@ -76,7 +76,7 @@ checkProof prop (ParseEquation reqns) env = errCtxtStr "Equational proof" $ do
     when (prop /= proved) $ err $
         text "Proved proposition does not match goal:" `indent` unparseProp proved
     return proved
-    
+
 checkProof prop (ParseExt withRaw toShowRaw proof) env = errCtxt ctxtMsg $
     flip evalStateT env $ do
         with <- validateWith withRaw
@@ -171,10 +171,10 @@ checkProof prop (ParseInduction dtRaw overRaw casesRaw) env = errCtxt ctxtMsg $ 
 
 checkProof prop (ParseCompInduction funRaw oversRaw casesRaw) env = errCtxt ctxtMsg $ do
     flip evalStateT env $ do
-        overs <- forM oversRaw validateOver 
+        overs <- forM oversRaw validateOver
         env <- get
         lift $ validateCases overs casesRaw env
-        return prop 
+        return prop
     where
         ctxtMsg = "Induction on the computation of" <+> quotes (text funRaw)
 
@@ -200,7 +200,7 @@ checkProof prop (ParseCompInduction funRaw oversRaw casesRaw) env = errCtxt ctxt
             | length overs < funArity = err $ hsep ["Fewer variables than arity of function", quotes (text funRaw), "given"]
             | length overs > funArity = err $ hsep ["More variables than arity of function", quotes (text funRaw), "given"]
             | caseNum < 1 = err "Case number must be at least 1"
-            | caseNum > length funEqs = 
+            | caseNum > length funEqs =
                 err $ hsep [ "The function", quotes (text funRaw), "has", int (length funEqs)
                            , "equations but got case number", int caseNum ]
             | otherwise = errCtxt (text "Case" <+> int caseNum) $ flip evalStateT env $ do
@@ -226,7 +226,7 @@ checkProof prop (ParseCompInduction funRaw oversRaw casesRaw) env = errCtxt ctxt
                                 env <- get
                                 Prop _ _ <- lift $ checkProof subgoal (pcbProof pcb) env
                                 return caseNum
-        
+
         recArgs t@(Application _ _)
             | t0 == Const symIf = []
             | t0 == Const funRaw = ts : concatMap recArgs ts
@@ -241,7 +241,7 @@ checkProof prop (ParseCompInduction funRaw oversRaw casesRaw) env = errCtxt ctxt
 
             lift $ forM pcHyps $ \(Named name prop) ->
                 case prop `elemIndex` indHyps of
-                    Just i -> return $ Named name $ generalizeExceptProp (foldr collectFrees [] (recArgs !! i)) prop 
+                    Just i -> return $ Named name $ generalizeExceptProp (foldr collectFrees [] (recArgs !! i)) prop
                     Nothing -> err $ ("Induction hypothesis" <+> text name <+> "is not valid")
                                      `indent` debug (unparseProp prop)
 
@@ -329,7 +329,7 @@ validEqnSeq rules (Step spos t1 rule es)
     | rewritesToWith rule rules t1 t2 = do
         Prop _ tLast <- validEqnSeq rules es
         return (Prop t1 tLast)
-    | otherwise = errCtxtStr (showSrcPos spos ++ " Invalid proof step " ++ noRuleMsg) $ err $
+    | otherwise = errCtxtStr (showSrcPos spos ++ " Invalid proof step" ++ noRuleMsg) $ err $
         unparseTerm t1 $+$ text ("(by " ++ rule ++ ") " ++ symPropEq) <+> unparseTerm t2
         $+$ debug (text rule Text.PrettyPrint.<> text ":" <+> vcat (map (unparseProp . namedVal) $ filter (\x -> namedName x == rule) rules))
   where

--- a/src/Test/Info2/Cyp/Util.hs
+++ b/src/Test/Info2/Cyp/Util.hs
@@ -7,12 +7,17 @@ module Test.Info2.Cyp.Util
     , errCtxtStr
     , indent
     , eitherToErr
+    , eitherToErrWith
     , renderSrcExtsFail
+    , showParsecErr
+    , showSrcPos
     )
 where
 
 import Language.Haskell.Exts (SrcLoc (..), ParseResult (..))
 import Text.PrettyPrint (Doc, (<+>), (<>), ($+$), colon, empty, int, nest, text)
+import qualified Text.Parsec as Parsec
+import qualified Text.Parsec.Error as Parsec.Error
 
 type Err = Either Doc
 
@@ -33,8 +38,11 @@ indent :: Doc -> Doc -> Doc
 indent d1 d2 = d1 $+$ nest 4 d2
 
 eitherToErr :: Show a => Either a b -> Err b
-eitherToErr (Left x) = err $ foldr (($+$) . text) empty (lines $ show x)
-eitherToErr (Right x) = Right x
+eitherToErr = eitherToErrWith show
+
+eitherToErrWith :: (a -> String) -> Either a b -> Err b
+eitherToErrWith showFun (Left x) = err $ foldr (($+$) . text) empty (lines $ showFun x)
+eitherToErrWith _ (Right x) = Right x
 
 debug :: Doc -> Doc
 --debug = mempty
@@ -45,3 +53,16 @@ renderSrcExtsFail _ (ParseOk _) = mempty
 renderSrcExtsFail typ (ParseFailed (SrcLoc _ _ col) msg) =
     (text "Failed to parse" <+> text typ <+> text "at position" <+> int col Text.PrettyPrint.<> colon)
     `indent` text msg
+
+showParsecErr :: Parsec.ParseError -> String
+showParsecErr e = showSrcPos pos ++ "\n" ++ msgsString
+    where
+        pos = Parsec.errorPos e
+        msgsString = Parsec.Error.showErrorMessages "or" "unknown parse error"
+                "expecting" "unexpected" "end of input" msgs
+        msgs = Parsec.Error.errorMessages e
+
+showSrcPos :: Parsec.SourcePos -> String
+showSrcPos pos = Parsec.sourceName pos ++ ":" ++
+        show (Parsec.sourceLine pos) ++ ":" ++
+        show (Parsec.sourceColumn pos) ++ ":"

--- a/test-data/neg/no-rule/cout
+++ b/test-data/neg/no-rule/cout
@@ -2,7 +2,7 @@ Lemma : length (xs ++ ys) .=. length xs + length ys
     Induction over variable 'xs' of type 'List'
         Case 'x : xs'
             Equational proof
-                Invalid proof step in line 31 (no rules with name "cheating")
+                test-data/neg/no-rule/cprf:31:9: Invalid proof step (no rules with name "cheating")
                     1 + length xs~1 + length ys~0
                     (by cheating) .=. 1 + (length xs~1 + length ys~0)
                     cheating:

--- a/test-data/neg/wrong-case/cout
+++ b/test-data/neg/wrong-case/cout
@@ -2,7 +2,7 @@ Lemma : length (xs ++ ys) .=. length xs + length ys
     Induction over variable 'xs' of type 'List'
         Case 'x : xs'
             Equational proof
-                Invalid proof step in line 25 (no rules with name "cheating")
+                test-data/neg/wrong-case/cprf:25:9: Invalid proof step (no rules with name "cheating")
                     length ((x~0 : xs~1) ++ ys~0)
                     (by cheating) .=. length (x~0 : xs~1 ++ ys~0)
                     cheating:


### PR DESCRIPTION
There are editors that rely on this format for underlining code and co.
Most compilers, eg. gcc and ghc, also use this.
